### PR TITLE
Added the ability to get a result from a Resolve func

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -13,6 +13,12 @@ type Resolver interface {
 	//	function if any error is returned
 	Resolve(interface{}) error
 
+	// ResolveWithResult will invoke the given function, resolving all of the arguments.
+	//  The provided function must return something, which this function will return via it's first return value
+	//	The returned error will either be from the Resolver failing to resolve an argument, or from the provided
+	//	function if any error is returned
+	ResolveWithResult(interface{}) (interface{}, error)
+
 	// resolveType will resolve the service with the given reflect.Type
 	resolveType(p reflect.Type) (interface{}, error)
 }
@@ -25,4 +31,15 @@ func validateScopeResults(fnValue reflect.Value) error {
 	}
 
 	return fmt.Errorf("func must return either nothing or an error")
+}
+
+func validateScopeResultsWithResponse(fnValue reflect.Value) error {
+	funcType := fnValue.Type()
+
+	if (funcType.NumOut() == 1 && funcType.Out(0).Name() != "error") ||
+		(funcType.NumOut() == 2 && funcType.Out(0).Name() != "error" && funcType.Out(1).Name() == "error") {
+		return nil
+	}
+
+	return fmt.Errorf("func must return something")
 }


### PR DESCRIPTION
You can now get a result from a `Resolver`. E.g:
```go
res, err := container.ResolveWithResult(func (mediator *medoator.Mediator) (*someResult, error) {
  result := mediator.Send(blah)
  return result, nil
})
```